### PR TITLE
addImportPath method and consider added paths in Qt.createComponent

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -74,10 +74,15 @@ function parseQML(file) {
 getUrlContents = function (url) {
     var xhr = new XMLHttpRequest();
     xhr.open("GET", url, false);
+    try {
     xhr.send(null);
     if (xhr.status != 200 && xhr.status != 0) { // 0 if accessing with file://
         console.log("Retrieving " + url + " failed: " + xhr.responseText, xhr);
-        return false;
+        return "";
+    }
+    } catch (e) {
+       console.log("Retrieving " + url + " failed with exception: ", e);
+       return "";
     }
     return xhr.responseText;
 }

--- a/src/import.js
+++ b/src/import.js
@@ -71,17 +71,19 @@ function parseQML(file) {
  * @private
  * @return {mixed} String of contents or false in errors.
  */
-getUrlContents = function (url) {
+getUrlContents = function (url,skipErrorLogging) {
     var xhr = new XMLHttpRequest();
     xhr.open("GET", url, false);
     try {
     xhr.send(null);
     if (xhr.status != 200 && xhr.status != 0) { // 0 if accessing with file://
-        console.log("Retrieving " + url + " failed: " + xhr.responseText, xhr);
+        if (!skipErrorLogging)
+          console.log("Retrieving " + url + " failed: " + xhr.responseText, xhr);
         return "";
     }
     } catch (e) {
-       console.log("Retrieving " + url + " failed with exception: ", e);
+       if (!skipErrorLogging)
+         console.log("Retrieving " + url + " failed with exception: ", e);
        return "";
     }
     return xhr.responseText;

--- a/src/qtcore.js
+++ b/src/qtcore.js
@@ -173,12 +173,12 @@ Qt.createComponent = function(name, executionContext)
 
     var file = engine.$basePath + name;
 
-    var src = getUrlContents(file);
+    var src = getUrlContents(file,true);
     if (src=="") {
         var moredirs = engine.importPathList();
         for (var i=0; i<moredirs.length; i++) {
           file = moredirs[i] + name;
-          src = getUrlContents(file);
+          src = getUrlContents(file,true);
           if (src != "") break;
         }
         if (src == "")

--- a/src/qtcore.js
+++ b/src/qtcore.js
@@ -797,11 +797,21 @@ QMLEngine = function (element, options) {
         }
         return this.$basePath + file;
     }
+    
+    // next 3 methods used in Qt.createComponent for qml files lookup
+    // please open qt site for documentation
+    // http://doc.qt.io/qt-5/qqmlengine.html#addImportPath
 
     this.addImportPath = function( dirpath ) {
       if (!this.userAddedLibraryPaths) this.userAddedImportPaths = [];
       this.userAddedImportPaths.push( dirpath );
     }
+
+    this.setImportPathList = function( arrayOfDirs )
+    {
+      this.userAddedImportPaths = arrayOfDirs;
+    }
+
     this.importPathList = function() {
       return (this.userAddedImportPaths || []);
     }

--- a/src/qtcore.js
+++ b/src/qtcore.js
@@ -174,8 +174,17 @@ Qt.createComponent = function(name, executionContext)
     var file = engine.$basePath + name;
 
     var src = getUrlContents(file);
-    if (src=="")
-        return undefined;
+    if (src=="") {
+        var moredirs = engine.importPathList();
+        for (var i=0; i<moredirs.length; i++) {
+          file = moredirs[i] + name;
+          src = getUrlContents(file);
+          if (src != "") break;
+        }
+        if (src == "")
+          return undefined;
+    }
+
     var tree = parseQML(src);
 
     if (tree.$children.length !== 1)
@@ -787,6 +796,14 @@ QMLEngine = function (element, options) {
             return file;
         }
         return this.$basePath + file;
+    }
+
+    this.addImportPath = function( dirpath ) {
+      if (!this.userAddedLibraryPaths) this.userAddedImportPaths = [];
+      this.userAddedImportPaths.push( dirpath );
+    }
+    this.importPathList = function() {
+      return (this.userAddedImportPaths || []);
     }
 
     this.$registerStart = function(f)

--- a/src/qtcore.js
+++ b/src/qtcore.js
@@ -176,11 +176,13 @@ Qt.createComponent = function(name, executionContext)
     var src = getUrlContents(file,true);
     if (src=="") {
         var moredirs = engine.importPathList();
+   
         for (var i=0; i<moredirs.length; i++) {
           file = moredirs[i] + name;
           src = getUrlContents(file,true);
           if (src != "") break;
         }
+
         if (src == "")
           return undefined;
     }
@@ -803,7 +805,7 @@ QMLEngine = function (element, options) {
     // http://doc.qt.io/qt-5/qqmlengine.html#addImportPath
 
     this.addImportPath = function( dirpath ) {
-      if (!this.userAddedLibraryPaths) this.userAddedImportPaths = [];
+      if (!this.userAddedImportPaths) this.userAddedImportPaths = [];
       this.userAddedImportPaths.push( dirpath );
     }
 


### PR DESCRIPTION
The idea is to tell to qmweb to lookup for qml files in various locations.
This is almost the same that we have in Qt.

The code only adds described behaviour to Qt.createComponent method (not to qmldir files lookup in import.js).
